### PR TITLE
Feature/expose ttl as vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The following resources will be created
 Prerequisites (Optional in example2):
 
   - Route 53 hosted zone for example.com
-  - ACM certificate for *.example.com in us-east-1 region
-  
+  - ACM certificate for `*.example.com in us-east-1 region`
+
 ### Example 1
 
     provider "aws" {
@@ -38,3 +38,17 @@ Prerequisites (Optional in example2):
         upload_sample_file     = true
     }
     
+### Cloudfront TTL settings
+
+* Cloudfront caches the static content at default values. However, if you change it constantly without recreating the bucket, you may need
+to decrease the TTL values.
+  * https://stackoverflow.com/questions/67845341/cloudfront-s3-etag-possible-for-cloudfront-to-send-updated-s3-object-before-t
+  * https://stackoverflow.com/questions/12783009/does-amazon-s3-send-invalidation-signals-to-cloudfront
+  * https://developers.google.com/speed/docs/insights/LeverageBrowserCaching
+
+```terraform
+        # optional values
+        cloudfront_min_ttl     = 10
+        cloudfront_default_ttl = 1400
+        cloudfront_max_ttl     = 86400
+```

--- a/example/main.tf
+++ b/example/main.tf
@@ -10,8 +10,11 @@ module "cloudfront_s3_website_with_domain" {
   use_default_domain     = false
   upload_sample_file     = true
   tags                   = var.tags
-}
 
+  cloudfront_min_ttl     = 10
+  cloudfront_default_ttl = 1400
+  cloudfront_max_ttl     = 86400
+}
 
 module "cloudfront_s3_website_without_domain" {
   source             = "../"

--- a/main.tf
+++ b/main.tf
@@ -127,9 +127,11 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
+  
+    # https://stackoverflow.com/questions/67845341/cloudfront-s3-etag-possible-for-cloudfront-to-send-updated-s3-object-before-t
+    min_ttl                = var.cloudfront_min_ttl
+    default_ttl            = var.cloudfront_default_ttl
+    max_ttl                = var.cloudfront_max_ttl
   }
 
   price_class = var.price_class

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,20 @@ variable "upload_sample_file" {
   default     = false
   description = "Upload sample html file to s3 bucket"
 }
+
+# All values for the TTL are important when uploading static content that changes
+# https://stackoverflow.com/questions/67845341/cloudfront-s3-etag-possible-for-cloudfront-to-send-updated-s3-object-before-t
+variable "cloudfront_min_ttl" {
+  default     = 0
+  description = "The minimum TTL for the cloudfront cache"
+}
+
+variable "cloudfront_default_ttl" {
+  default     = 86400
+  description = "The default TTL for the cloudfront cache"
+}
+
+variable "cloudfront_max_ttl" {
+  default     = 31536000
+  description = "The maximum TTL for the cloudfront cache"
+}


### PR DESCRIPTION
This is described at the so below. If the static page changes
but we want to keep the same URL, we should just use a different
TTL for the content instead of creating a whole new bucket.

https://stackoverflow.com/questions/67845341/cloudfront-s3-etag-possible-for-cloudfront-to-send-updated-s3-object-before-t

# 🔧 Variables

* Those are described in detailed at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy

# 📝 Other references

* https://stackoverflow.com/questions/12783009/does-amazon-s3-send-invalidation-signals-to-cloudfront
* https://developers.google.com/speed/docs/insights/LeverageBrowserCaching

# 🪅 Updated values

> Using my fork, version `1.3.0` https://registry.terraform.io/modules/marcellodesales/cloudfront-s3-website/aws/latest

With the exposed values I was able to update exisiting TTL settings

<img width="1213" alt="Screen Shot 2022-03-19 at 2 34 05 PM" src="https://user-images.githubusercontent.com/131457/159139192-62b9a949-c938-4570-9efe-d121141bfac8.png">

# 🔊 Logs

```console
s3-website_1  |   # aws_s3_bucket_object.object1["index.html"] will be updated in-place
s3-website_1  |   ~ resource "aws_s3_bucket_object" "object1" {
s3-website_1  |       ~ etag               = "b57106a01b6d2a5956c39f3a4f4c3bc8" -> "ae433ab7f780be56aff4a8999f40946f"
s3-website_1  |         id                 = "index.html"
s3-website_1  |         tags               = {}
s3-website_1  |       ~ version_id         = "z5NalA5YFKS1a8dN.5z0a7Z1i9IetvI." -> (known after apply)
s3-website_1  |         # (10 unchanged attributes hidden)
s3-website_1  |     }
s3-website_1  | 
s3-website_1  |   # aws_s3_bucket_object.object1["version.json"] will be updated in-place
s3-website_1  |   ~ resource "aws_s3_bucket_object" "object1" {
s3-website_1  |       ~ etag               = "85cd952e759641caaef580e9ea7b29c4" -> "56bac85bc59a4c297a21aa6eaee4eae9"
s3-website_1  |         id                 = "version.json"
s3-website_1  |         tags               = {}
s3-website_1  |       ~ version_id         = "3wsCQu23e13sftvtFhjoWWhYmLBldVLr" -> (known after apply)
s3-website_1  |         # (10 unchanged attributes hidden)
s3-website_1  |     }
s3-website_1  | 
s3-website_1  |   # module.cloudfront_s3_website_with_domain.aws_cloudfront_distribution.s3_distribution will be updated in-place
s3-website_1  |   ~ resource "aws_cloudfront_distribution" "s3_distribution" {
s3-website_1  |         id                             = "E2SQPKM4EI3QD3"
s3-website_1  |         tags                           = {
s3-website_1  |             "application" = "MaceioShoppingWeb"
s3-website_1  |             "owner"       = "Supercash"
s3-website_1  |         }
s3-website_1  |         # (19 unchanged attributes hidden)
s3-website_1  | 
s3-website_1  | 
s3-website_1  |       ~ default_cache_behavior {
s3-website_1  |           ~ default_ttl            = 86400 -> 1400
s3-website_1  |           ~ max_ttl                = 31536000 -> 86400
s3-website_1  |           ~ min_ttl                = 0 -> 10
s3-website_1  |             # (8 unchanged attributes hidden)
s3-website_1  | 
s3-website_1  |             # (1 unchanged block hidden)
s3-website_1  |         }
s3-website_1  | 
s3-website_1  | 
s3-website_1  | 
s3-website_1  |         # (4 unchanged blocks hidden)
s3-website_1  |     }
s3-website_1  | 
```
